### PR TITLE
Implement MIMO ARP shaper and DRAG utilities

### DIFF
--- a/quantum/__init__.py
+++ b/quantum/__init__.py
@@ -1,0 +1,3 @@
+"""Quantum control helpers."""
+
+__all__ = []

--- a/quantum/core_mimo_arp.py
+++ b/quantum/core_mimo_arp.py
@@ -1,0 +1,73 @@
+import numpy as np
+from typing import Iterable
+
+
+def mimo_arp_shaper(S: np.ndarray, M: np.ndarray, alpha: np.ndarray, dt: float, method: str = "euler"):
+    """Simple MIMO ARP shaper using forward Euler integration.
+
+    Args:
+        S: Target envelopes with shape (C, T).
+        M: Coupling matrix with shape (C, C).
+        alpha: Per-channel drive strengths (C,).
+        dt: Time step.
+        method: Integration method (only "euler" supported).
+
+    Returns:
+        Tuple of (A, dA_dt) each of shape (C, T).
+    """
+    C, T = S.shape
+    A = np.zeros_like(S)
+    dA = np.zeros_like(S)
+    for k in range(1, T):
+        dA[:, k - 1] = alpha * S[:, k - 1] - M @ A[:, k - 1]
+        if method == "euler":
+            A[:, k] = A[:, k - 1] + dt * dA[:, k - 1]
+        else:
+            raise ValueError(f"Unsupported method: {method}")
+    dA[:, -1] = alpha * S[:, - 1] - M @ A[:, -1]
+    return A, dA
+
+
+def apply_drag(A: np.ndarray, dA_dt: np.ndarray, Delta: np.ndarray, beta: float = 1.0, pairs: Iterable[tuple[int, int]] | None = None) -> np.ndarray:
+    """Apply DRAG quadrature to paired I/Q channels.
+
+    Args:
+        A: Pulses array (C, T).
+        dA_dt: Time derivatives of pulses (C, T).
+        Delta: Detunings per pair (P,).
+        beta: Scaling factor for DRAG term.
+        pairs: Iterable of (I, Q) channel index pairs. Defaults to consecutive pairs.
+
+    Returns:
+        Modified pulses with DRAG applied.
+    """
+    A2 = A.copy()
+    if pairs is None:
+        pairs = [(i, i + 1) for i in range(0, A.shape[0], 2)]
+    for i_ch, q_ch in pairs:
+        pair_index = i_ch // 2
+        A2[q_ch, :] += -beta * dA_dt[i_ch, :] / Delta[pair_index]
+    return A2
+
+
+def rfft_all(X: np.ndarray) -> np.ndarray:
+    """Real FFT along the time axis for all channels."""
+    return np.fft.rfft(X, axis=1)
+
+
+def band_mag(freq: np.ndarray, spec: np.ndarray, f0: float, bw: float) -> float:
+    """Average magnitude of spectrum within a frequency band."""
+    sel = (freq >= f0 - bw) & (freq <= f0 + bw)
+    if np.any(sel):
+        return float(np.mean(np.abs(spec[sel])))
+    return 0.0
+
+
+def amp_noise_integral(freq: np.ndarray, specs: Iterable[np.ndarray], A1: float = 1.0, A0: float = 0.05) -> float:
+    """Amplitude noise integral for a collection of spectra."""
+    w = freq.copy()
+    if w[0] == 0:
+        w[0] = w[1]
+    power = sum(np.abs(s) ** 2 for s in specs)
+    d_w = freq[1] - freq[0]
+    return float(np.sum((A1 / w + A0) * power) * d_w)

--- a/quantum/cost.py
+++ b/quantum/cost.py
@@ -1,0 +1,26 @@
+from dataclasses import dataclass
+from typing import Any, Dict, Tuple
+
+
+@dataclass
+class CostWeights:
+    lambda_amp: float = 2e-5
+    lambda_leak: float = 5e-4
+    lambda_xt: float = 2e-3
+    lambda_T: float = 1e-4
+    gate_cap_ns: float | None = 80.0
+
+
+def cost_J(A, freq, settings, weights: CostWeights) -> Tuple[float, Dict[str, Any]]:
+    """Placeholder cost function returning zeros.
+
+    Args:
+        A: Pulse amplitudes.
+        freq: Frequency grid.
+        settings: Control settings.
+        weights: Weights for cost components.
+
+    Returns:
+        A tuple of (total_cost, parts_dict).
+    """
+    return 0.0, {}

--- a/quantum/settings.py
+++ b/quantum/settings.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+
+@dataclass
+class ARPSettings:
+    """Minimal settings for quantum control experiments."""
+    T1: Sequence[float]
+    Tphi: Sequence[float]
+    Delta: Sequence[float]
+    pairs: Iterable[tuple[int, int]] = ((0, 1), (2, 3))
+    xt_bands: Iterable[tuple[float, float]] = ()

--- a/tests/test_core_mimo_arp.py
+++ b/tests/test_core_mimo_arp.py
@@ -1,0 +1,54 @@
+import numpy as np
+from quantum.core_mimo_arp import (
+    mimo_arp_shaper,
+    apply_drag,
+    rfft_all,
+    band_mag,
+)
+
+
+def test_mimo_arp_shaper_matches_analytic():
+    T = 100
+    dt = 0.01
+    S = np.ones((1, T))
+    M = np.array([[0.5]])
+    alpha = np.array([1.0])
+    A, dA = mimo_arp_shaper(S, M, alpha, dt)
+    t = np.arange(T) * dt
+    # Analytic solution for dA/dt = alpha*S - m*A with S=1
+    m = M[0, 0]
+    A_exact = alpha[0] / m * (1 - np.exp(-m * t))
+    assert np.allclose(A[0], A_exact, atol=1e-2)
+    # derivative should match at final step
+    assert np.allclose(dA[0, -1], alpha[0] * S[0, -1] - m * A[0, -1])
+
+
+def test_apply_drag_pairs():
+    C, T = 4, 5
+    A = np.zeros((C, T))
+    dA_dt = np.zeros((C, T))
+    dA_dt[0] = np.arange(T)
+    dA_dt[2] = 2 * np.arange(T)
+    Delta = np.array([2.0, 4.0])
+    A2 = apply_drag(A, dA_dt, Delta)
+    expected_q0 = -dA_dt[0] / Delta[0]
+    expected_q1 = -dA_dt[2] / Delta[1]
+    assert np.allclose(A2[1], expected_q0)
+    assert np.allclose(A2[3], expected_q1)
+    # I channels remain unchanged
+    assert np.allclose(A2[0], 0)
+    assert np.allclose(A2[2], 0)
+
+
+def test_fft_band_mag():
+    dt = 0.01
+    T = 100
+    t = np.arange(T) * dt
+    freq0 = 10.0
+    x = np.sin(2 * np.pi * freq0 * t)
+    spec = rfft_all(x[None, :])[0]
+    freq = np.fft.rfftfreq(T, dt)
+    mag_sig = band_mag(freq, spec, freq0, 1.0)
+    mag_off = band_mag(freq, spec, 30.0, 1.0)
+    assert mag_sig > 1.0
+    assert mag_off < 1e-3


### PR DESCRIPTION
## Summary
- add core MIMO-ARP shaper with DRAG helper and spectral metrics
- scaffold cost weights and settings dataclasses
- exercise shaper, DRAG, and FFT band magnitude in unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899c909490c832fa7b904f4d67c249e