### PR TITLE
Add GRAPE wrapper, quantum ladder harness, and QUBO benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,27 @@ These files are no longer used—parameters such as `CONTEXT_SCHEDULE` are now
 declared directly in the training scripts.  The JSON files have therefore been
 removed.
 
+## Benchmarks
+
+### Quantum Control Ladder XT
+Run the 4-qubit ladder cross-talk benchmark:
+
+```bash
+python benchmarks/quantum-control/ladder4_xt.py --cfg configs/ladder4_xt.yaml --method gaussian
+```
+
+Replace `--method` with `diag-arp`, `mimo-arp`, or `mimo-arp+grape` for other strategies.
+
+### QUBO Benchmark
+Evaluate optimizers on a random QUBO:
+
+```bash
+python benchmarks/ml/qubo_benchmark.py --n 512 --density 0.05 --opt adamw
+python benchmarks/ml/qubo_benchmark.py --n 512 --density 0.05 --opt adamw-realignr-cma
+```
+
+Logs are written to `logs/`.
+
 ## License
 
 This project is licensed under the MIT License - see the LICENSE file for details.

--- a/benchmarks/ml/qubo_benchmark.py
+++ b/benchmarks/ml/qubo_benchmark.py
@@ -1,0 +1,116 @@
+import argparse
+import time
+from pathlib import Path
+
+import torch
+import pandas as pd
+
+from optim.realignr import RealignR
+
+
+def make_Q(n, density, seed=0):
+    g = torch.Generator().manual_seed(seed)
+    idx = torch.randperm(n * n, generator=g)[: int(density * n * n)]
+    Q = torch.zeros(n * n)
+    Q[idx] = torch.randn(idx.size(0), generator=g)
+    Q = Q.view(n, n)
+    Q = (Q + Q.t()) / 2
+    return Q
+
+
+def loss(Q, z, tau=1.0, ent=1e-3):
+    x = torch.sigmoid(z / tau)
+    E = x @ Q @ x
+    H = -(x * torch.log(x + 1e-8) + (1 - x) * torch.log(1 - x + 1e-8)).mean()
+    return E + ent * H, dict(E=float(E.detach()), H=float(H.detach()))
+
+
+def run(args):
+    device = torch.device('cpu')
+    Q = make_Q(args.n, args.density, args.seed).to(device)
+    z = torch.zeros(args.n, device=device, requires_grad=True)
+    steps = args.steps
+    tau0, tau1 = 2.0, 0.3
+    out_dir = Path('logs'); out_dir.mkdir(exist_ok=True)
+
+    def cosine_tau(k):
+        t = k / steps
+        return tau1 + 0.5 * (tau0 - tau1) * (1 + torch.cos(torch.tensor(t * 3.1415926535)))
+
+    opt_name = args.opt
+    if opt_name == 'adamw':
+        opt = torch.optim.AdamW([z], lr=args.lr)
+        switch = None
+    elif opt_name == 'adagrad':
+        opt = torch.optim.Adagrad([z], lr=args.lr)
+        switch = None
+    elif opt_name in ('adamw-adagrad', 'adamw-realignr', 'adamw-realignr-cma'):
+        opt = torch.optim.AdamW([z], lr=args.lr)
+        def _make_second():
+            if opt_name == 'adamw-adagrad':
+                return torch.optim.Adagrad([z], lr=args.lr)
+            else:
+                return RealignR([z], lr=args.lr, mu=0.1, alpha=1.0,
+                                cma_xi=0.1 if 'cma' in opt_name else 0.0,
+                                cma_beta=0.05 if 'cma' in opt_name else 0.0)
+        switch = _make_second
+    else:
+        raise ValueError('unknown opt')
+
+    log = []
+    E_best = float('inf')
+    switched = False
+    trigger_step = None
+    trigger_gap = None
+    escape_time = None
+    start = time.time()
+    for k in range(1, steps + 1):
+        tau = float(cosine_tau(k))
+        opt.zero_grad()
+        L, parts = loss(Q, z, tau)
+        L.backward()
+        opt.step()
+        E = parts['E']
+        if E < E_best:
+            E_best = E
+        gap = (E - E_best) / abs(E_best)
+        g = z.grad.detach()
+        grad_var = float(g.var())
+        snr = float(g.mean().abs() / (g.std() + 1e-8))
+        log.append(dict(step=k, loss=float(L.detach()), E=E, tau=tau,
+                        gap=float(gap), grad_var=grad_var, snr=snr))
+        if switch and not switched:
+            if k >= int(0.4 * steps):
+                window = log[-5:]
+                if len(window) == 5:
+                    slope = (window[-1]['loss'] - window[0]['loss']) / max(abs(window[0]['loss']), 1e-9)
+                    if slope > -0.001:
+                        opt = switch()
+                        switched = True
+                        trigger_step = k
+                        trigger_gap = gap
+        if switched and escape_time is None and trigger_gap is not None:
+            if gap <= trigger_gap * 0.9:
+                escape_time = k - trigger_step
+    elapsed = time.time() - start
+    df = pd.DataFrame(log)
+    df.to_csv(out_dir / f'qubo_{opt_name}.csv', index=False)
+    pd.DataFrame([dict(final_gap=float(gap), escape_time=escape_time,
+                       elapsed=elapsed)]).to_csv(out_dir / f'qubo_{opt_name}_summary.csv', index=False)
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument('--n', type=int, required=True)
+    p.add_argument('--density', type=float, required=True)
+    p.add_argument('--opt', required=True,
+                   choices=['adamw', 'adagrad', 'adamw-adagrad', 'adamw-realignr', 'adamw-realignr-cma'])
+    p.add_argument('--steps', type=int, default=200)
+    p.add_argument('--lr', type=float, default=1e-2)
+    p.add_argument('--seed', type=int, default=0)
+    args = p.parse_args()
+    run(args)
+
+
+if __name__ == '__main__':
+    main()

--- a/benchmarks/quantum-control/ladder4_xt.py
+++ b/benchmarks/quantum-control/ladder4_xt.py
@@ -1,0 +1,85 @@
+import argparse
+import yaml
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+from pathlib import Path
+
+from quantum.core_mimo_arp import mimo_arp_shaper, apply_drag, rfft_all
+from quantum.cost import cost_J, PhysSettings, CostWeights
+from quantum.grape_wrapper import grape_optimize
+from quantum.optimizers import ARPGrad
+
+
+def run(cfg, method):
+    out_dir = Path('outputs')
+    out_dir.mkdir(exist_ok=True)
+    dt, T_ns = cfg['dt_ns'], cfg['T_ns']
+    t = np.arange(0, T_ns, dt)
+    freq = np.fft.rfftfreq(t.size, d=dt)
+    C = 8
+    S = np.zeros((C, t.size))
+    S[0, int(20/dt):int(40/dt)] = 1.0
+    S[4, int(20/dt):int(40/dt)] = 1.0
+    settings = PhysSettings(T1_us=cfg['T1_us'], Tphi_us=cfg['Tphi_us'],
+                            f_anh_GHz=tuple(cfg['anh_GHz']),
+                            f_xt_GHz=tuple(cfg['spectator_GHz']),
+                            gate_cap_ns=cfg['T_ns'])
+    wts = CostWeights()
+    A = S.copy()
+    log_df = pd.DataFrame()
+    if method in ('diag-arp', 'mimo-arp', 'mimo-arp+grape'):
+        tau = cfg['tau_ns']; mu = 1.0 / tau
+        M = np.eye(C) * mu
+        if method.startswith('mimo'):
+            xt = cfg['xt_mean']
+            M += xt * (np.ones((C, C)) - np.eye(C))
+        alpha = np.array([mu] * C)
+        A, dA = mimo_arp_shaper(S, M, alpha, dt)
+        Delta = 2 * np.pi * np.array(cfg['anh_GHz'])
+        A = apply_drag(A, dA, Delta, iq_pairs=[(2*i, 2*i+1) for i in range(4)])
+        if method == 'mimo-arp+grape':
+            U0 = {f'U{ch}': A[ch].copy() for ch in range(A.shape[0])}
+            def build_A(U):
+                return np.vstack([U[k] for k in sorted(U.keys())])
+            def cost_wrap(Ap):
+                return cost_J(Ap, freq, settings, wts)
+            smoother = ARPGrad() if cfg.get('spsa_steps', 0) else None
+            U_opt, log_df = grape_optimize(build_A, cost_wrap, U0,
+                                           steps=cfg['grape_steps'],
+                                           lr=cfg['grape_lr'],
+                                           samples=cfg['grape_samples'],
+                                           time_cap_ns=cfg['T_ns'],
+                                           smoother=smoother,
+                                           seed=cfg['seed'])
+            A = build_A(U_opt)
+    J, parts = cost_J(A, freq, settings, wts)
+    if log_df.empty:
+        log_df = pd.DataFrame([{'iter': 0, 'EPC': J, **parts}])
+    summary = pd.DataFrame([{'method': method, 'EPC': J, **parts}])
+    log_df.to_csv(out_dir / 'ladder4_xt_log.csv', index=False)
+    summary.to_csv(out_dir / 'ladder4_xt_summary.csv', index=False)
+    plt.figure(); plt.plot(log_df['iter'], log_df['EPC']); plt.xlabel('iter'); plt.ylabel('EPC');
+    plt.savefig(out_dir / 'epc_vs_iter.png'); plt.close()
+    plt.figure(); plt.plot([cfg['tau_ns']], [J], 'o'); plt.xlabel('tau_ns'); plt.ylabel('EPC');
+    plt.savefig(out_dir / 'diag_arp_tau_curve.png'); plt.close()
+    plt.figure(); plt.bar(range(4), [parts.get('leak', 0)]*4); plt.xlabel('qubit'); plt.ylabel('leak');
+    plt.savefig(out_dir / 'leakage_per_qubit.png'); plt.close()
+    spec = np.abs(rfft_all(A))
+    plt.figure(); plt.plot(freq, spec[0]); plt.xlabel('freq'); plt.ylabel('mag');
+    plt.savefig(out_dir / 'spectrum_pre_post.png'); plt.close()
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument('--cfg', required=True)
+    p.add_argument('--method', required=True,
+                   choices=['gaussian', 'diag-arp', 'mimo-arp', 'mimo-arp+grape'])
+    args = p.parse_args()
+    with open(args.cfg, 'r') as f:
+        cfg = yaml.safe_load(f)
+    run(cfg, args.method)
+
+
+if __name__ == '__main__':
+    main()

--- a/configs/ladder4_xt.yaml
+++ b/configs/ladder4_xt.yaml
@@ -1,0 +1,15 @@
+dt_ns: 0.05
+T_ns: 140.0
+T1_us: 50.0
+Tphi_us: 20.0
+anh_GHz: [0.24, 0.25, 0.26, 0.27]
+spectator_GHz: [0.07, 0.08, 0.09]
+xt_mean: 0.10
+xt_sigma: 0.03
+tau_ns: 2.0
+spsa_steps: 80
+spsa_bounds: [0.0, 0.3]
+grape_steps: 250
+grape_lr: 0.2
+grape_samples: 64
+seed: 42

--- a/optim/realignr.py
+++ b/optim/realignr.py
@@ -3,75 +3,27 @@ from torch.optim.optimizer import Optimizer
 
 
 class RealignR(Optimizer):
-    r"""Leaky-integrator optimizer: ``v = (1-μ) v + α g`` followed by
-    ``θ ← θ - η v`` with decoupled weight decay.
-
-    Args:
-        params (iterable): parameters to optimize.
-        lr (float, optional): learning rate. Default: ``1e-3``.
-        mu (float, optional): leak coefficient. Default: ``0.1``.
-        alpha (float, optional): gradient scaling factor. Default: ``1.0``.
-        weight_decay (float, optional): decoupled weight decay. Default: ``0``.
-        cma_xi (float, optional): curvature modulation strength. ``0`` disables
-            curvature-modulated gain (CMA).
-        cma_beta (float, optional): EMA coefficient for curvature proxy.
-    """
-
-    def __init__(
-        self,
-        params,
-        lr: float = 1e-3,
-        mu: float = 0.1,
-        alpha: float = 1.0,
-        weight_decay: float = 0.0,
-        cma_xi: float = 0.0,
-        cma_beta: float = 0.0,
-    ):
-        defaults = dict(
-            lr=lr,
-            mu=mu,
-            alpha=alpha,
-            weight_decay=weight_decay,
-            cma_xi=cma_xi,
-            cma_beta=cma_beta,
-        )
-        super().__init__(params, defaults)
+    def __init__(self, params, lr=1e-3, mu=0.1, alpha=1.0,
+                 weight_decay=0.0, cma_xi=0.0, cma_beta=0.0):
+        super().__init__(params, dict(lr=lr, mu=mu, alpha=alpha,
+                                      weight_decay=weight_decay,
+                                      cma_xi=cma_xi, cma_beta=cma_beta))
 
     @torch.no_grad()
     def step(self):
-        loss = None
-        for group in self.param_groups:
-            lr = group["lr"]
-            mu = group["mu"]
-            alpha = group["alpha"]
-            wd = group["weight_decay"]
-            xi = group["cma_xi"]
-            beta = group["cma_beta"]
-
-            for p in group["params"]:
+        for g in self.param_groups:
+            lr, mu, alpha = g['lr'], g['mu'], g['alpha']
+            wd, xi, beta = g['weight_decay'], g['cma_xi'], g['cma_beta']
+            for p in g['params']:
                 if p.grad is None:
                     continue
-                g = p.grad
-
-                # Decoupled weight decay
-                if wd != 0:
-                    p.data.mul_(1 - lr * wd)
-
-                state = self.state[p]
-                if "v" not in state:
-                    state["v"] = torch.zeros_like(p)
-                    state["g_ema2"] = torch.zeros((), device=p.device)
-
-                v = state["v"]
-                g2 = state["g_ema2"]
-
-                # Simple curvature proxy: EMA of squared gradient norm
-                g2.mul_(1 - beta).add_(beta * g.pow(2).mean())
-
-                # CMA gain modulation
-                alpha_eff = alpha / (1.0 + xi * g2.sqrt())
-
-                # Leaky integrator update
-                v.mul_(1 - mu).add_(alpha_eff * g)
+                if wd:
+                    p.mul_(1 - lr * wd)
+                st = self.state.setdefault(p, {})
+                v = st.get('v', torch.zeros_like(p))
+                g2 = st.get('g2', torch.zeros((), device=p.device))
+                g2.mul_(1 - beta).add_(beta * p.grad.pow(2).mean())
+                alpha_eff = alpha / (1 + xi * g2.sqrt())
+                v.mul_(1 - mu).add_(alpha_eff * p.grad)
                 p.add_(v, alpha=-lr)
-        return loss
+                st['v'], st['g2'] = v, g2

--- a/quantum/grape_wrapper.py
+++ b/quantum/grape_wrapper.py
@@ -1,0 +1,77 @@
+# MIT License
+import numpy as np
+import pandas as pd
+from typing import Callable
+from .core_mimo_arp import rfft_all, amp_noise_integral
+
+
+def grape_optimize(build_A: Callable[[dict], np.ndarray],
+                   cost_J: Callable[[np.ndarray], tuple[float, dict]],
+                   U0: dict,
+                   steps: int = 300, lr: float = 0.2, samples: int = 64,
+                   eps: float = 1e-3, momentum: float = 0.9,
+                   smoother=None, time_cap_ns: float = 80.0,
+                   seed: int = 0):
+    """Finite-difference GRAPE with optional gradient smoothing.
+
+    ``build_A(U)`` builds shaped pulses from controls ``U``.
+    ``cost_J(A)`` returns (EPC_like, parts_dict).
+    ``U0`` is a dict of initial controls, e.g. {"Ic": np.ndarray(T)}.
+
+    Returns ``(U_opt, log_df)`` where ``log_df`` contains columns
+    ``iter, EPC, gate_ns, amp_int`` plus any parts from ``cost_J``.
+    """
+    rng = np.random.default_rng(seed)
+    U = {k: v.astype(float).copy() for k, v in U0.items()}
+    M = {k: np.zeros_like(v) for k, v in U.items()}
+    A0 = build_A(U)
+    C, T = A0.shape
+    freq = np.fft.rfftfreq(T, d=1.0)
+
+    def full_cost(Udict):
+        A = build_A(Udict)
+        J, parts = cost_J(A)
+        Aw = rfft_all(A)
+        amp_int = amp_noise_integral(freq, [Aw[ch, :] for ch in range(C)])
+        J += 2e-5 * amp_int
+        def eff_len_samples(x, thr=1e-3):
+            idx = np.where(np.abs(x) > thr)[0]
+            return 0 if len(idx) == 0 else (idx[-1] - idx[0])
+        gate_ns = 0.0
+        for q in range(C // 2):
+            gate_ns = max(gate_ns, eff_len_samples(A[2 * q, :]))
+        if gate_ns > time_cap_ns:
+            J += 1e-4 * (gate_ns - time_cap_ns) ** 2
+        parts.update(dict(gate_ns=float(gate_ns), amp_int=float(amp_int)))
+        return float(J), parts
+
+    log = []
+    for k in range(1, steps + 1):
+        J, parts = full_cost(U)
+        log.append({"iter": k, "EPC": J, **parts})
+        total_len = sum(v.size for v in U.values())
+        idx_flat = rng.choice(total_len, size=min(samples, total_len), replace=False)
+        grads = {key: np.zeros_like(U[key]) for key in U}
+        for flat in idx_flat:
+            cum = 0
+            for key in U:
+                arr = U[key]
+                n = arr.size
+                if flat < cum + n:
+                    i = flat - cum
+                    old = arr.flat[i]
+                    arr.flat[i] = old + eps
+                    Jp, _ = full_cost(U)
+                    arr.flat[i] = old - eps
+                    Jm, _ = full_cost(U)
+                    arr.flat[i] = old
+                    grads[key].flat[i] = (Jp - Jm) / (2 * eps)
+                    break
+                cum += n
+        if smoother:
+            for key in grads:
+                grads[key] = smoother.apply(grads[key])
+        for key in U:
+            M[key] = momentum * M[key] + (1 - momentum) * grads[key]
+            U[key] -= lr * M[key]
+    return U, pd.DataFrame(log)

--- a/test_grape_wrapper.py
+++ b/test_grape_wrapper.py
@@ -1,0 +1,24 @@
+import numpy as np
+from quantum.grape_wrapper import grape_optimize
+
+
+def test_grape_smoke():
+    T = 100
+    Ic = np.zeros(T); Ic[:40] = 1.0
+    It = np.zeros(T); It[:40] = 1.0
+    U0 = {"Ic": Ic, "It": It}
+
+    def build_A(U):
+        A = np.zeros((2, T))
+        A[0, :40] = U["Ic"][:40]
+        A[1, :40] = U["It"][:40]
+        return A
+
+    def cost_J(A):
+        return float(np.mean(A ** 2)), {}
+
+    U_opt, log = grape_optimize(build_A, cost_J, U0,
+                                steps=10, lr=0.1, samples=100,
+                                time_cap_ns=80.0, seed=0, momentum=0.0)
+    assert log["EPC"].iloc[-1] < log["EPC"].iloc[0]
+    assert log["gate_ns"].max() <= 80.0


### PR DESCRIPTION
## Summary
- implement GRAPE optimizer wrapper with amplitude noise and gate-time penalties
- add 4-qubit ladder cross-talk benchmark and config file
- provide QUBO benchmark script and simplified RealignR optimizer
- document running the new benchmarks

## Testing
- `pytest test_grape_wrapper.py::test_grape_smoke -q`

------
https://chatgpt.com/codex/tasks/task_e_6899d3d9a178832f87a3044783cc47a1