### PR TITLE
Add GitHub Sponsors link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: RDM3DC

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ARPPiAGradientDescent Optimizer Suite
 
+[![Sponsor](https://img.shields.io/badge/Sponsor-RDM3DC-pink)](https://github.com/sponsors/RDM3DC)
+
 ## Overview
 
 ARPPiAGradientDescent is a novel optimization algorithm that combines Activity-Regulated Plasticity (ARP) with Pi-Adaptive (πₐ) rotation for neural network training. This repository contains implementations, enhanced versions, and comprehensive experiments showcasing the optimizer's performance and behavior.


### PR DESCRIPTION
## Summary
- highlight GitHub Sponsors page with a badge in README
- enable sponsor button via `.github/FUNDING.yml`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b8e556aa8c832faec4a15e18837d39